### PR TITLE
release: v1.0.35

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "wp-content-framework/cache",
-            "version": "v1.0.26",
+            "version": "v1.0.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-content-framework/cache.git",
-                "reference": "b195bb1c3da9cb8b7d3a7524beaab9c73aa46172"
+                "reference": "dada2562747f11097bbfa7e795cf61fcf2826eb9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-content-framework/cache/zipball/b195bb1c3da9cb8b7d3a7524beaab9c73aa46172",
-                "reference": "b195bb1c3da9cb8b7d3a7524beaab9c73aa46172",
+                "url": "https://api.github.com/repos/wp-content-framework/cache/zipball/dada2562747f11097bbfa7e795cf61fcf2826eb9",
+                "reference": "dada2562747f11097bbfa7e795cf61fcf2826eb9",
                 "shasum": ""
             },
             "require": {
@@ -52,7 +52,7 @@
             ],
             "support": {
                 "issues": "https://github.com/wp-content-framework/cache/issues",
-                "source": "https://github.com/wp-content-framework/cache/tree/v1.0.26"
+                "source": "https://github.com/wp-content-framework/cache/tree/v1.0.27"
             },
             "funding": [
                 {
@@ -60,20 +60,20 @@
                     "type": "custom"
                 }
             ],
-            "time": "2020-11-17T12:36:43+00:00"
+            "time": "2020-12-01T12:52:22+00:00"
         },
         {
             "name": "wp-content-framework/common",
-            "version": "v1.0.27",
+            "version": "v1.0.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-content-framework/common.git",
-                "reference": "7a0ca27bc29f96d612914b1f1a0884bf7ab53a38"
+                "reference": "3b50b640be5999accdf2525503f48373d35e4b89"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-content-framework/common/zipball/7a0ca27bc29f96d612914b1f1a0884bf7ab53a38",
-                "reference": "7a0ca27bc29f96d612914b1f1a0884bf7ab53a38",
+                "url": "https://api.github.com/repos/wp-content-framework/common/zipball/3b50b640be5999accdf2525503f48373d35e4b89",
+                "reference": "3b50b640be5999accdf2525503f48373d35e4b89",
                 "shasum": ""
             },
             "require": {
@@ -108,7 +108,7 @@
             ],
             "support": {
                 "issues": "https://github.com/wp-content-framework/common/issues",
-                "source": "https://github.com/wp-content-framework/common/tree/v1.0.27"
+                "source": "https://github.com/wp-content-framework/common/tree/v1.0.28"
             },
             "funding": [
                 {
@@ -116,7 +116,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2020-11-17T09:11:32+00:00"
+            "time": "2020-12-01T06:17:14+00:00"
         }
     ],
     "packages-dev": [
@@ -1507,23 +1507,23 @@
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/1de8cd5c010cb153fcd68b8d0f64606f523f7619",
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": ">=5.6"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.0"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
@@ -1550,9 +1550,15 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/master"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/1.0.2"
             },
-            "time": "2017-03-04T06:30:41+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:15:22+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -2116,16 +2122,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v5.1.8",
+            "version": "v5.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "11baeefa4c179d6908655a7b6be728f62367c193"
+                "reference": "fa1219ecbf96bb5db59f2599cba0960a0d9c3aea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/11baeefa4c179d6908655a7b6be728f62367c193",
-                "reference": "11baeefa4c179d6908655a7b6be728f62367c193",
+                "url": "https://api.github.com/repos/symfony/config/zipball/fa1219ecbf96bb5db59f2599cba0960a0d9c3aea",
+                "reference": "fa1219ecbf96bb5db59f2599cba0960a0d9c3aea",
                 "shasum": ""
             },
             "require": {
@@ -2174,7 +2180,7 @@
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v5.1.8"
+                "source": "https://github.com/symfony/config/tree/v5.2.0"
             },
             "funding": [
                 {
@@ -2190,20 +2196,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T12:01:57+00:00"
+            "time": "2020-11-16T18:02:40+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v5.1.8",
+            "version": "v5.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "829ca6bceaf68036a123a13a979f3c89289eae78"
+                "reference": "98cec9b9f410a4832e239949a41d47182862c3a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/829ca6bceaf68036a123a13a979f3c89289eae78",
-                "reference": "829ca6bceaf68036a123a13a979f3c89289eae78",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/98cec9b9f410a4832e239949a41d47182862c3a4",
+                "reference": "98cec9b9f410a4832e239949a41d47182862c3a4",
                 "shasum": ""
             },
             "require": {
@@ -2261,7 +2267,7 @@
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v5.1.8"
+                "source": "https://github.com/symfony/dependency-injection/tree/v5.2.0"
             },
             "funding": [
                 {
@@ -2277,7 +2283,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-27T10:11:13+00:00"
+            "time": "2020-11-28T11:24:18+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2348,16 +2354,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.1.8",
+            "version": "v5.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "df08650ea7aee2d925380069c131a66124d79177"
+                "reference": "bb92ba7f38b037e531908590a858a04d85c0e238"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/df08650ea7aee2d925380069c131a66124d79177",
-                "reference": "df08650ea7aee2d925380069c131a66124d79177",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/bb92ba7f38b037e531908590a858a04d85c0e238",
+                "reference": "bb92ba7f38b037e531908590a858a04d85c0e238",
                 "shasum": ""
             },
             "require": {
@@ -2390,7 +2396,7 @@
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.1.8"
+                "source": "https://github.com/symfony/filesystem/tree/v5.2.0"
             },
             "funding": [
                 {
@@ -2406,7 +2412,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T12:01:57+00:00"
+            "time": "2020-11-12T09:58:18+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2651,16 +2657,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v4.4.16",
+            "version": "v4.4.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "543cb4dbd45ed803f08a9a65f27fb149b5dd20c2"
+                "reference": "7531361cf38e4816821b4a12a42542b3c6143ad1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/543cb4dbd45ed803f08a9a65f27fb149b5dd20c2",
-                "reference": "543cb4dbd45ed803f08a9a65f27fb149b5dd20c2",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/7531361cf38e4816821b4a12a42542b3c6143ad1",
+                "reference": "7531361cf38e4816821b4a12a42542b3c6143ad1",
                 "shasum": ""
             },
             "require": {
@@ -2702,7 +2708,7 @@
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v4.4.16"
+                "source": "https://github.com/symfony/yaml/tree/v4.4.17"
             },
             "funding": [
                 {
@@ -2718,7 +2724,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T11:50:19+00:00"
+            "time": "2020-11-24T12:28:30+00:00"
         },
         {
             "name": "webmozart/assert",


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* chore: update dependencies (0991d0ab1fcf20c426427da7554b1395a0682b0a)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/wp-content-framework/core/tree/master)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>composer prepare</em></summary>

```Shell
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/php-compatibility,../../phpcompatibility/phpcompatibility-paragonie,../../phpcompatibility/phpcompatibility-wp,../../wp-coding-standards/wpcs

>> Copy files.
>>>> phpmd.xml
>>>> phpcs.xml
>>>> phpunit.xml
```

### stderr:

```Shell
> mkdir -p ./fixtures/.git
> chmod -R +w ./fixtures/.git && rm -rdf ./fixtures
> rm -f ./phpcs.xml ./phpmd.xml ./phpunit.xml
> git clone --depth=1 https://github.com/wp-content-framework/fixtures.git fixtures
Cloning into 'fixtures'...
> WORKSPACE=${WORKSPACE:-$(cd $(dirname $0); pwd)} bash ./fixtures/bin/prepare.sh
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^0.7.0 for dealerdirect/phpcodesniffer-composer-installer
Using version ^2.9 for phpmd/phpmd
Using version ^3.5 for squizlabs/php_codesniffer
Using version ^2.3 for wp-coding-standards/wpcs
Using version ^2.1 for phpcompatibility/phpcompatibility-wp
./composer.json has been updated
Running composer update dealerdirect/phpcodesniffer-composer-installer phpmd/phpmd squizlabs/php_codesniffer wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp
Loading composer repositories with package information
Updating dependencies
Lock file operations: 46 installs, 0 updates, 0 removals
  - Locking composer/xdebug-handler (1.4.5)
  - Locking dealerdirect/phpcodesniffer-composer-installer (v0.7.0)
  - Locking doctrine/instantiator (1.4.0)
  - Locking myclabs/deep-copy (1.10.2)
  - Locking pdepend/pdepend (2.8.0)
  - Locking phake/phake (v2.3.2)
  - Locking phpcompatibility/php-compatibility (9.3.5)
  - Locking phpcompatibility/phpcompatibility-paragonie (1.3.0)
  - Locking phpcompatibility/phpcompatibility-wp (2.1.0)
  - Locking phpdocumentor/reflection-common (2.2.0)
  - Locking phpdocumentor/reflection-docblock (5.2.2)
  - Locking phpdocumentor/type-resolver (1.4.0)
  - Locking phpmd/phpmd (2.9.1)
  - Locking phpspec/prophecy (v1.10.3)
  - Locking phpunit/php-code-coverage (4.0.8)
  - Locking phpunit/php-file-iterator (1.4.5)
  - Locking phpunit/php-text-template (1.2.1)
  - Locking phpunit/php-timer (1.0.9)
  - Locking phpunit/php-token-stream (2.0.2)
  - Locking phpunit/phpunit (5.7.27)
  - Locking phpunit/phpunit-mock-objects (3.4.4)
  - Locking psr/container (1.0.0)
  - Locking psr/log (1.1.3)
  - Locking sebastian/code-unit-reverse-lookup (1.0.2)
  - Locking sebastian/comparator (1.2.4)
  - Locking sebastian/diff (1.4.3)
  - Locking sebastian/environment (2.0.0)
  - Locking sebastian/exporter (2.0.0)
  - Locking sebastian/global-state (1.1.1)
  - Locking sebastian/object-enumerator (2.0.1)
  - Locking sebastian/recursion-context (2.0.0)
  - Locking sebastian/resource-operations (1.0.0)
  - Locking sebastian/version (2.0.1)
  - Locking squizlabs/php_codesniffer (3.5.8)
  - Locking symfony/config (v5.2.0)
  - Locking symfony/dependency-injection (v5.2.0)
  - Locking symfony/deprecation-contracts (v2.2.0)
  - Locking symfony/filesystem (v5.2.0)
  - Locking symfony/polyfill-ctype (v1.20.0)
  - Locking symfony/polyfill-php80 (v1.20.0)
  - Locking symfony/service-contracts (v2.2.0)
  - Locking symfony/yaml (v4.4.17)
  - Locking webmozart/assert (1.9.1)
  - Locking wp-coding-standards/wpcs (2.3.0)
  - Locking wp-content-framework/cache (v1.0.27)
  - Locking wp-content-framework/common (v1.0.28)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 46 installs, 0 updates, 0 removals
  - Downloading squizlabs/php_codesniffer (3.5.8)
  - Downloading dealerdirect/phpcodesniffer-composer-installer (v0.7.0)
  - Downloading sebastian/recursion-context (2.0.0)
  - Downloading sebastian/exporter (2.0.0)
  - Downloading sebastian/diff (1.4.3)
  - Downloading sebastian/comparator (1.2.4)
  - Downloading phake/phake (v2.3.2)
  - Downloading phpcompatibility/php-compatibility (9.3.5)
  - Downloading phpcompatibility/phpcompatibility-paragonie (1.3.0)
  - Downloading phpcompatibility/phpcompatibility-wp (2.1.0)
  - Downloading symfony/polyfill-ctype (v1.20.0)
  - Downloading webmozart/assert (1.9.1)
  - Downloading phpdocumentor/reflection-common (2.2.0)
  - Downloading phpdocumentor/type-resolver (1.4.0)
  - Downloading phpdocumentor/reflection-docblock (5.2.2)
  - Downloading symfony/filesystem (v5.2.0)
  - Downloading psr/container (1.0.0)
  - Downloading symfony/service-contracts (v2.2.0)
  - Downloading symfony/polyfill-php80 (v1.20.0)
  - Downloading symfony/deprecation-contracts (v2.2.0)
  - Downloading symfony/dependency-injection (v5.2.0)
  - Downloading symfony/config (v5.2.0)
  - Downloading pdepend/pdepend (2.8.0)
  - Downloading psr/log (1.1.3)
  - Downloading composer/xdebug-handler (1.4.5)
  - Downloading phpmd/phpmd (2.9.1)
  - Downloading phpunit/php-token-stream (2.0.2)
  - Downloading symfony/yaml (v4.4.17)
  - Downloading sebastian/version (2.0.1)
  - Downloading sebastian/resource-operations (1.0.0)
  - Downloading sebastian/object-enumerator (2.0.1)
  - Downloading sebastian/global-state (1.1.1)
  - Downloading sebastian/environment (2.0.0)
  - Downloading phpunit/php-text-template (1.2.1)
  - Downloading doctrine/instantiator (1.4.0)
  - Downloading phpunit/phpunit-mock-objects (3.4.4)
  - Downloading phpunit/php-timer (1.0.9)
  - Downloading phpunit/php-file-iterator (1.4.5)
  - Downloading sebastian/code-unit-reverse-lookup (1.0.2)
  - Downloading phpunit/php-code-coverage (4.0.8)
  - Downloading phpspec/prophecy (v1.10.3)
  - Downloading myclabs/deep-copy (1.10.2)
  - Downloading phpunit/phpunit (5.7.27)
  - Downloading wp-coding-standards/wpcs (2.3.0)
  - Downloading wp-content-framework/cache (v1.0.27)
  - Downloading wp-content-framework/common (v1.0.28)
  0/46 [>---------------------------]   0%
  1/46 [>---------------------------]   2%
  2/46 [=>--------------------------]   4%
  3/46 [=>--------------------------]   6%
  4/46 [==>-------------------------]   8%
  5/46 [===>------------------------]  10%
  6/46 [===>------------------------]  13%
  7/46 [====>-----------------------]  15%
  8/46 [====>-----------------------]  17%
  9/46 [=====>----------------------]  19%
 10/46 [======>---------------------]  21%
 11/46 [======>---------------------]  23%
 12/46 [=======>--------------------]  26%
 13/46 [=======>--------------------]  28%
 14/46 [========>-------------------]  30%
 15/46 [=========>------------------]  32%
 16/46 [=========>------------------]  34%
 17/46 [==========>-----------------]  36%
 18/46 [==========>-----------------]  39%
 19/46 [===========>----------------]  41%
 20/46 [============>---------------]  43%
 21/46 [============>---------------]  45%
 22/46 [=============>--------------]  47%
 23/46 [==============>-------------]  50%
 24/46 [==============>-------------]  52%
 25/46 [===============>------------]  54%
 26/46 [===============>------------]  56%
 27/46 [================>-----------]  58%
 28/46 [=================>----------]  60%
 29/46 [=================>----------]  63%
 30/46 [==================>---------]  65%
 31/46 [==================>---------]  67%
 32/46 [===================>--------]  69%
 33/46 [====================>-------]  71%
 34/46 [====================>-------]  73%
 35/46 [=====================>------]  76%
 36/46 [=====================>------]  78%
 37/46 [======================>-----]  80%
 38/46 [=======================>----]  82%
 39/46 [=======================>----]  84%
 40/46 [========================>---]  86%
 41/46 [========================>---]  89%
 42/46 [=========================>--]  91%
 43/46 [==========================>-]  93%
 44/46 [==========================>-]  95%
 45/46 [===========================>]  97%
 46/46 [============================] 100%  - Installing squizlabs/php_codesniffer (3.5.8): Extracting archive
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.7.0): Extracting archive
  - Installing sebastian/recursion-context (2.0.0): Extracting archive
  - Installing sebastian/exporter (2.0.0): Extracting archive
  - Installing sebastian/diff (1.4.3): Extracting archive
  - Installing sebastian/comparator (1.2.4): Extracting archive
  - Installing phake/phake (v2.3.2): Extracting archive
  - Installing phpcompatibility/php-compatibility (9.3.5): Extracting archive
  - Installing phpcompatibility/phpcompatibility-paragonie (1.3.0): Extracting archive
  - Installing phpcompatibility/phpcompatibility-wp (2.1.0): Extracting archive
  - Installing symfony/polyfill-ctype (v1.20.0): Extracting archive
  - Installing webmozart/assert (1.9.1): Extracting archive
  - Installing phpdocumentor/reflection-common (2.2.0): Extracting archive
  - Installing phpdocumentor/type-resolver (1.4.0): Extracting archive
  - Installing phpdocumentor/reflection-docblock (5.2.2): Extracting archive
  - Installing symfony/filesystem (v5.2.0): Extracting archive
  - Installing psr/container (1.0.0): Extracting archive
  - Installing symfony/service-contracts (v2.2.0): Extracting archive
  - Installing symfony/polyfill-php80 (v1.20.0): Extracting archive
  - Installing symfony/deprecation-contracts (v2.2.0): Extracting archive
  - Installing symfony/dependency-injection (v5.2.0): Extracting archive
  - Installing symfony/config (v5.2.0): Extracting archive
  - Installing pdepend/pdepend (2.8.0): Extracting archive
  - Installing psr/log (1.1.3): Extracting archive
  - Installing composer/xdebug-handler (1.4.5): Extracting archive
  - Installing phpmd/phpmd (2.9.1): Extracting archive
  - Installing phpunit/php-token-stream (2.0.2): Extracting archive
  - Installing symfony/yaml (v4.4.17): Extracting archive
  - Installing sebastian/version (2.0.1): Extracting archive
  - Installing sebastian/resource-operations (1.0.0): Extracting archive
  - Installing sebastian/object-enumerator (2.0.1): Extracting archive
  - Installing sebastian/global-state (1.1.1): Extracting archive
  - Installing sebastian/environment (2.0.0): Extracting archive
  - Installing phpunit/php-text-template (1.2.1): Extracting archive
  - Installing doctrine/instantiator (1.4.0): Extracting archive
  - Installing phpunit/phpunit-mock-objects (3.4.4): Extracting archive
  - Installing phpunit/php-timer (1.0.9): Extracting archive
  - Installing phpunit/php-file-iterator (1.4.5): Extracting archive
  - Installing sebastian/code-unit-reverse-lookup (1.0.2): Extracting archive
  - Installing phpunit/php-code-coverage (4.0.8): Extracting archive
  - Installing phpspec/prophecy (v1.10.3): Extracting archive
  - Installing myclabs/deep-copy (1.10.2): Extracting archive
  - Installing phpunit/phpunit (5.7.27): Extracting archive
  - Installing wp-coding-standards/wpcs (2.3.0): Extracting archive
  - Installing wp-content-framework/cache (v1.0.27): Extracting archive
  - Installing wp-content-framework/common (v1.0.28): Extracting archive
  0/34 [>---------------------------]   0%
 10/34 [========>-------------------]  29%
 20/34 [================>-----------]  58%
 30/34 [========================>---]  88%
 31/34 [=========================>--]  91%
 33/34 [===========================>]  97%
 34/34 [============================] 100%11 package suggestions were added by new dependencies, use `composer suggest` to see details.
Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
Package phpunit/phpunit-mock-objects is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
16 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^1.0 for wp-content-framework/common
Using version ^1.0 for wp-content-framework/cache
./composer.json has been updated
Running composer update wp-content-framework/common wp-content-framework/cache
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Nothing to install, update or remove
Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
Package phpunit/phpunit-mock-objects is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
16 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Nothing to install, update or remove
Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
Package phpunit/phpunit-mock-objects is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
16 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```

</details>
<details>
<summary><em>composer packages</em></summary>

```Shell
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/php-compatibility,../../phpcompatibility/phpcompatibility-paragonie,../../phpcompatibility/phpcompatibility-wp,../../wp-coding-standards/wpcs
```

### stderr:

```Shell
> WORKSPACE=${WORKSPACE:-$(cd $(dirname $0); pwd)} bash ./fixtures/bin/packages.sh
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^0.7.0 for dealerdirect/phpcodesniffer-composer-installer
Using version ^2.9 for phpmd/phpmd
Using version ^3.5 for squizlabs/php_codesniffer
Using version ^2.3 for wp-coding-standards/wpcs
Using version ^2.1 for phpcompatibility/phpcompatibility-wp
./composer.json has been updated
Running composer update dealerdirect/phpcodesniffer-composer-installer phpmd/phpmd squizlabs/php_codesniffer wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp
Loading composer repositories with package information
Updating dependencies
Lock file operations: 46 installs, 0 updates, 0 removals
  - Locking composer/xdebug-handler (1.4.5)
  - Locking dealerdirect/phpcodesniffer-composer-installer (v0.7.0)
  - Locking doctrine/instantiator (1.4.0)
  - Locking myclabs/deep-copy (1.10.2)
  - Locking pdepend/pdepend (2.8.0)
  - Locking phake/phake (v2.3.2)
  - Locking phpcompatibility/php-compatibility (9.3.5)
  - Locking phpcompatibility/phpcompatibility-paragonie (1.3.0)
  - Locking phpcompatibility/phpcompatibility-wp (2.1.0)
  - Locking phpdocumentor/reflection-common (2.2.0)
  - Locking phpdocumentor/reflection-docblock (5.2.2)
  - Locking phpdocumentor/type-resolver (1.4.0)
  - Locking phpmd/phpmd (2.9.1)
  - Locking phpspec/prophecy (v1.10.3)
  - Locking phpunit/php-code-coverage (4.0.8)
  - Locking phpunit/php-file-iterator (1.4.5)
  - Locking phpunit/php-text-template (1.2.1)
  - Locking phpunit/php-timer (1.0.9)
  - Locking phpunit/php-token-stream (2.0.2)
  - Locking phpunit/phpunit (5.7.27)
  - Locking phpunit/phpunit-mock-objects (3.4.4)
  - Locking psr/container (1.0.0)
  - Locking psr/log (1.1.3)
  - Locking sebastian/code-unit-reverse-lookup (1.0.2)
  - Locking sebastian/comparator (1.2.4)
  - Locking sebastian/diff (1.4.3)
  - Locking sebastian/environment (2.0.0)
  - Locking sebastian/exporter (2.0.0)
  - Locking sebastian/global-state (1.1.1)
  - Locking sebastian/object-enumerator (2.0.1)
  - Locking sebastian/recursion-context (2.0.0)
  - Locking sebastian/resource-operations (1.0.0)
  - Locking sebastian/version (2.0.1)
  - Locking squizlabs/php_codesniffer (3.5.8)
  - Locking symfony/config (v5.2.0)
  - Locking symfony/dependency-injection (v5.2.0)
  - Locking symfony/deprecation-contracts (v2.2.0)
  - Locking symfony/filesystem (v5.2.0)
  - Locking symfony/polyfill-ctype (v1.20.0)
  - Locking symfony/polyfill-php80 (v1.20.0)
  - Locking symfony/service-contracts (v2.2.0)
  - Locking symfony/yaml (v4.4.17)
  - Locking webmozart/assert (1.9.1)
  - Locking wp-coding-standards/wpcs (2.3.0)
  - Locking wp-content-framework/cache (v1.0.27)
  - Locking wp-content-framework/common (v1.0.28)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 46 installs, 0 updates, 0 removals
    0 [>---------------------------]    0 [>---------------------------]  - Installing squizlabs/php_codesniffer (3.5.8): Extracting archive
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.7.0): Extracting archive
  - Installing sebastian/recursion-context (2.0.0): Extracting archive
  - Installing sebastian/exporter (2.0.0): Extracting archive
  - Installing sebastian/diff (1.4.3): Extracting archive
  - Installing sebastian/comparator (1.2.4): Extracting archive
  - Installing phake/phake (v2.3.2): Extracting archive
  - Installing phpcompatibility/php-compatibility (9.3.5): Extracting archive
  - Installing phpcompatibility/phpcompatibility-paragonie (1.3.0): Extracting archive
  - Installing phpcompatibility/phpcompatibility-wp (2.1.0): Extracting archive
  - Installing symfony/polyfill-ctype (v1.20.0): Extracting archive
  - Installing webmozart/assert (1.9.1): Extracting archive
  - Installing phpdocumentor/reflection-common (2.2.0): Extracting archive
  - Installing phpdocumentor/type-resolver (1.4.0): Extracting archive
  - Installing phpdocumentor/reflection-docblock (5.2.2): Extracting archive
  - Installing symfony/filesystem (v5.2.0): Extracting archive
  - Installing psr/container (1.0.0): Extracting archive
  - Installing symfony/service-contracts (v2.2.0): Extracting archive
  - Installing symfony/polyfill-php80 (v1.20.0): Extracting archive
  - Installing symfony/deprecation-contracts (v2.2.0): Extracting archive
  - Installing symfony/dependency-injection (v5.2.0): Extracting archive
  - Installing symfony/config (v5.2.0): Extracting archive
  - Installing pdepend/pdepend (2.8.0): Extracting archive
  - Installing psr/log (1.1.3): Extracting archive
  - Installing composer/xdebug-handler (1.4.5): Extracting archive
  - Installing phpmd/phpmd (2.9.1): Extracting archive
  - Installing phpunit/php-token-stream (2.0.2): Extracting archive
  - Installing symfony/yaml (v4.4.17): Extracting archive
  - Installing sebastian/version (2.0.1): Extracting archive
  - Installing sebastian/resource-operations (1.0.0): Extracting archive
  - Installing sebastian/object-enumerator (2.0.1): Extracting archive
  - Installing sebastian/global-state (1.1.1): Extracting archive
  - Installing sebastian/environment (2.0.0): Extracting archive
  - Installing phpunit/php-text-template (1.2.1): Extracting archive
  - Installing doctrine/instantiator (1.4.0): Extracting archive
  - Installing phpunit/phpunit-mock-objects (3.4.4): Extracting archive
  - Installing phpunit/php-timer (1.0.9): Extracting archive
  - Installing phpunit/php-file-iterator (1.4.5): Extracting archive
  - Installing sebastian/code-unit-reverse-lookup (1.0.2): Extracting archive
  - Installing phpunit/php-code-coverage (4.0.8): Extracting archive
  - Installing phpspec/prophecy (v1.10.3): Extracting archive
  - Installing myclabs/deep-copy (1.10.2): Extracting archive
  - Installing phpunit/phpunit (5.7.27): Extracting archive
  - Installing wp-coding-standards/wpcs (2.3.0): Extracting archive
  - Installing wp-content-framework/cache (v1.0.27): Extracting archive
  - Installing wp-content-framework/common (v1.0.28): Extracting archive
  0/34 [>---------------------------]   0%
 10/34 [========>-------------------]  29%
 20/34 [================>-----------]  58%
 30/34 [========================>---]  88%
 32/34 [==========================>-]  94%
 34/34 [============================] 100%11 package suggestions were added by new dependencies, use `composer suggest` to see details.
Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
Package phpunit/phpunit-mock-objects is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
16 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^1.0 for wp-content-framework/common
Using version ^1.0 for wp-content-framework/cache
./composer.json has been updated
Running composer update wp-content-framework/common wp-content-framework/cache
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Nothing to install, update or remove
Package phpunit/php-token-stream is abandoned, you should avoid using it. No replacement was suggested.
Package phpunit/phpunit-mock-objects is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
16 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```

</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- composer.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)